### PR TITLE
Fix the bug where windows-wrapper logs are missing when loaded as windows service

### DIFF
--- a/src/main/java/org/neo4j/wrapper/LoggingService.java
+++ b/src/main/java/org/neo4j/wrapper/LoggingService.java
@@ -19,38 +19,121 @@
  */
 package org.neo4j.wrapper;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.logging.LogManager;
 
+/**
+ * The logging service is mainly responsible for doing two things:
+ * <ul>
+ * <li>    1) Reset the value of property {@code java.util.logging.FileHandler.pattern} (which is defined in
+ * {@code windows-wrapper-logging.properties} file) to an absolute path if it is given as a relative path.
+ * The absolute path uses our default working directory {@code %NEO4J_HOME%} as its parent directory.
+ * <li>    2) Create directories if they do not exist before for the path specified by
+ * {@code java.util.logging.FileHandler.pattern}.
+ * </ul>
+ *
+ * The property {@code java.util.logging.FileHandler.pattern} defines where the windows-wrapper logs are stored.
+ * If it is given in a relative path, the {@code java.util.logging} will use the place where the program runs as
+ * the parent path. However by default, we assume that the parent directory should always be our working directory
+ * {@code %NEO4J_HOME%}. Therefore we need to reset the relative path to a full path to avoid logs being created in
+ * an unexpected place.
+ *
+ * Besides we also need to create missing directories on this path to avoid
+ * {@link java.util.logging.FileHandler#openFiles IO exceptions}.
+ * <p>
+ * The value of property {@code java.util.logging.FileHandler.pattern} uses a special pattern format. More info
+ * about the pattern format could be found in {@link java.util.logging.FileHandler FileHandler}
+ */
 public class LoggingService
 {
-    private static final String LOGGING_CONFIG_FILE_KEY = "java.util.logging.config.file";
+    static final String LOGGING_CONFIG_FILE_KEY = "java.util.logging.config.file";
+    static final String LOGGING_FILE_NAME_PATTERN_KEY = "java.util.logging.FileHandler.pattern";
+
     private static final String DEFAULT_LOGGING_CONFIG_FILE_PATH = getDefaultLoggingConfigFilePath();
-    private static final String LOGGING_FILE_NAME_PATTERN_KEY = "java.util.logging.FileHandler.pattern";
+    private String winWrapperLogNamePattern;
 
-    public static void initLogger() throws FileNotFoundException, IOException
+    public LoggingService()
     {
-        // Load all the properties from logging.properties
-        String logConfigFileName = System.getProperty( LOGGING_CONFIG_FILE_KEY, DEFAULT_LOGGING_CONFIG_FILE_PATH );
-        Properties logProperties = new Properties();
-        logProperties.load( new FileInputStream( new File( logConfigFileName ) ) );
+    }
 
-        // Find the logging directory and create the directory if not exists.
-        String logFileNamePattern = logProperties.getProperty( LOGGING_FILE_NAME_PATTERN_KEY );
-        File logDir = getLogDir( logFileNamePattern );
+    // only for testing
+    LoggingService( String pattern )
+    {
+        this.winWrapperLogNamePattern = pattern;
+    }
 
+    public void initLogger() throws IOException
+    {
+        LogManager logManager = LogManager.getLogManager();
+        winWrapperLogNamePattern = logManager.getProperty( LOGGING_FILE_NAME_PATTERN_KEY );
+
+        // Reset the pattern property if is relative
+        if ( namePatternIsRelative() )
+        {
+            resetLogNamePatternProperty( logManager );
+        }
+
+        // Retrieve the logging directory from the pattern property and create the directory if it does not exist.
+        File logDir = getLogDir();
         if ( !logDir.exists() )
         {
             logDir.mkdirs();
         }
     }
 
+    private boolean namePatternIsRelative()
+    {
+        boolean isInTempDir = winWrapperLogNamePattern.startsWith( "%h" );
+        boolean isInUserHomeDir = winWrapperLogNamePattern.startsWith( "%t" );
+        boolean isRelative = !new File( winWrapperLogNamePattern ).isAbsolute();
+        return !isInTempDir && !isInUserHomeDir && isRelative;
+    }
+
     /**
-     * The input pattern is used by the {@link java.util.logging.FileHandler} to generate log files.
-     * The input pattern consists of some special components that will be replaced at runtime by the FileHandler class:
+     * Change the value of property {@code java.util.logging.FileHandler.pattern} to use {@code %NEO4J_HOME%} as parent
+     * directory and call {@link java.util.logging.LogManager LogManager} to reload the change.
+     * <p>
+     * By invoking this method, we ensure no matter where a user starts NEO4J, we will always use {@code %NEO4J_HOME%}
+     * as parent directory for windows-wrapper logs. Otherwise, we will use the directory where the program
+     * starts as the parent directory when creating windows-wrapper logs.
+     * @param logManager
+     * @throws IOException if we failed to read from the windows-wrapper property file or update configuration
+     * properties for {@link java.util.logging.LogManager LogManager}
+     */
+    void resetLogNamePatternProperty( LogManager logManager )
+            throws IOException
+    {
+        // Load all the properties from configuration file
+        String logConfigFileName = System.getProperty( LOGGING_CONFIG_FILE_KEY, DEFAULT_LOGGING_CONFIG_FILE_PATH );
+        try ( FileInputStream logConfigIn = new FileInputStream( new File( logConfigFileName ) ) )
+        {
+            Properties logProperties = new Properties();
+            logProperties.load( logConfigIn );
+
+            // Reset the logFileNamePattern to use %NEO4J_HOME% as its parent folder
+            String workingDir = System.getProperty( ServerProcess.WorkingDir );
+            workingDir = workingDir.replaceAll( "%", "%%" ); // translate to the format used by FileHandler
+            winWrapperLogNamePattern = new File( workingDir, winWrapperLogNamePattern ).getAbsolutePath();
+
+            // Reload the new change
+            logProperties.setProperty( LOGGING_FILE_NAME_PATTERN_KEY, winWrapperLogNamePattern );
+            ByteArrayOutputStream internalOut = new ByteArrayOutputStream();
+            logProperties.store( internalOut, null );
+            logManager.readConfiguration( new ByteArrayInputStream( internalOut.toByteArray() ) );
+        }
+    }
+
+    /**
+     * This method returns the directory in which the windows-wrapper logs will be generated. The path to this directory
+     * could be retrieved from the property {@code java.util.logging.FileHandler.pattern}. However the property
+     * utilizes a special path pattern.
+     * The pattern consists of some special components that will be replaced at runtime by
+     * {@link java.util.logging.FileHandler FileHandler}:
      * <ul>
      * <li>    "/"    the local pathname separator
      * <li>     "%t"   the system temporary directory
@@ -60,17 +143,17 @@ public class LoggingService
      * <li>     "%%"   translates to a single percent sign "%"
      * </ul>
      *
-     * This method will return a file representing the parent directory of the input pattern.
-     * However, this method will throw {@link java.io.IOException} if the directory contains components in wrong positions:
+     * This method will throw {@link java.io.IOException IOException} if the directory path contains components
+     * in wrong positions:
      *
      * <ul>
      * <li>     having "%t" or "%h" in the middle of the directory path
      * <li>     having "%g" or "%u" in the directory path
      * </ul>
      **/
-    protected static File getLogDir( String logFileNamePattern ) throws IOException
+    File getLogDir() throws IOException
     {
-        String logDirNamePattern = new File( logFileNamePattern ).getParent();
+        String logDirNamePattern = new File( winWrapperLogNamePattern ).getParent();
         String logDirParentDirName = null;
 
         //
@@ -107,12 +190,12 @@ public class LoggingService
                 case 'g':
                     throw new IOException(
                             "Cannot make directories automatically for directory paths containing %u or %g: "
-                                    + new File( logFileNamePattern ).getParent() + "; Please change \""
-                                    + LOGGING_FILE_NAME_PATTERN_KEY + "=" + logFileNamePattern + "\"" );
+                                    + new File( winWrapperLogNamePattern ).getParent() + "; Please change \""
+                                    + LOGGING_FILE_NAME_PATTERN_KEY + "=" + winWrapperLogNamePattern + "\"" );
                 case 't':
                 case 'h':
-                    throw new IOException( "Cannot understand %t or %h in the middle of a path: " + logFileNamePattern
-                            + "; Please change \"" + LOGGING_FILE_NAME_PATTERN_KEY + "=" + logFileNamePattern + "\"" );
+                    throw new IOException( "Cannot understand %t or %h in the middle of a path: " + winWrapperLogNamePattern
+                            + "; Please change \"" + LOGGING_FILE_NAME_PATTERN_KEY + "=" + winWrapperLogNamePattern + "\"" );
                 }
             }
         }

--- a/src/main/java/org/neo4j/wrapper/NeoServiceWrapper.java
+++ b/src/main/java/org/neo4j/wrapper/NeoServiceWrapper.java
@@ -31,7 +31,7 @@ public class NeoServiceWrapper
     {
         try
         {
-            LoggingService.initLogger();
+            new LoggingService().initLogger();
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
Windows-wrapper uses a relative path to specify where the logs are stored. When setting this path, we assume that the parent path is %NEO4J_HOME%. However when running Neo4j as a windows service using WindowsInstaller.bat, the parent path points to C:\Windows\System32. As a result, users might fail to find the logging files in the right place. This pr ensures that the windows-wrapper logging files always use %NEO4J_HOME% as default parent path.
